### PR TITLE
Fix up grafana api rotation issue

### DIFF
--- a/.github/workflows/aws_cicd.yaml
+++ b/.github/workflows/aws_cicd.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           directory: infrastructure/aws/cdktf.out/stacks/
           framework: terraform_plan
-          skip_check: CKV_AWS_116,CKV_AWS_117,CKV_AWS_272
+          skip_check: CKV_AWS_116,CKV_AWS_117,CKV_AWS_272,CKV2_AWS_57
         
       - name: Dev deployment
         run: make aws-deploy-all INFRA_ARGS=--auto-approve

--- a/infrastructure/aws/cdktf.json
+++ b/infrastructure/aws/cdktf.json
@@ -4,7 +4,7 @@
   "projectId": "ab6ba306-5f3e-4a6e-88ce-c23e56898e9d",
   "sendCrashReports": "false",
   "terraformProviders": [
-    "grafana/grafana@~> 1.37"
+    "grafana/grafana@~> 1.40"
   ],
   "terraformModules": [],
   "codeMakerOutput": "imports",

--- a/infrastructure/aws/dynamo_db_component.py
+++ b/infrastructure/aws/dynamo_db_component.py
@@ -18,6 +18,9 @@ class DynamoDBcomponent(Construct):
             "flight_controller_core_dynamodb_key",
             description="Flight Controller Core DynamoDB KMS Key",
             enable_key_rotation=True,
+            lifecycle={
+                "prevent_destroy": True
+            }
         )
 
         # create dynamoDB table

--- a/infrastructure/aws/grafana_lambda_with_permissions_component.py
+++ b/infrastructure/aws/grafana_lambda_with_permissions_component.py
@@ -27,7 +27,8 @@ class GrafanaLambdaComponent(Construct):
         id: str,
         name: str,
         grafanaWorkspace: grafana_workspace.GrafanaWorkspace,
-        dynamo_db_key: str
+        api_kms_key: str,
+        workspace_id_kms_key: str
     ):
         super().__init__(scope, id)
 
@@ -45,7 +46,10 @@ class GrafanaLambdaComponent(Construct):
             self,
             "flight_controller_grafana_rotation_lambda_key",
             description="Flight Controller Grafana Rotation Lambda KMS Key",
-            enable_key_rotation=True
+            enable_key_rotation=True,
+            lifecycle={
+                "prevent_destroy": True
+            }
         )
 
         # CREATE roles
@@ -95,8 +99,13 @@ class GrafanaLambdaComponent(Construct):
                                         "kms:Decrypt",
                                         "kms:Encrypt",
                                         "kms:CreateGrant",
+                                        "kms:ReEncrypt*",
+                                        "kms:GenerateDataKey*"
                                     ],
-                                    "Resource": dynamo_db_key,
+                                    "Resource": [
+                                        api_kms_key,
+                                        workspace_id_kms_key
+                                    ],
                                     "Effect": "Allow",
                                 },
                                 {

--- a/infrastructure/aws/lambda_with_permissions_component.py
+++ b/infrastructure/aws/lambda_with_permissions_component.py
@@ -52,6 +52,9 @@ class LambdaWithPermissionsComponent(Construct):
             "flight_controller_core_lambda_key",
             description="Flight Controller Core Lambda KMS Key",
             enable_key_rotation=True,
+            lifecycle={
+                "prevent_destroy": True
+            }
         )
 
         # CREATE roles

--- a/infrastructure/aws/main.py
+++ b/infrastructure/aws/main.py
@@ -66,7 +66,7 @@ class AwsCore(TerraformStack):
 
         # Create lambda function to rotate Grafana key 
         grafanaLambdaComponent = GrafanaLambdaComponent(
-            self, "grafana_function", self.grafana_lambda_name, grafanaWorkspace.grafana_workspace, dynamoDBcomponent.key.arn
+            self, "grafana_function", self.grafana_lambda_name, grafanaWorkspace.grafana_workspace, grafanaWorkspace.api_kms_key.arn, grafanaWorkspace.workspace_id_kms_key.arn
         )
 
         # Create rotation rules to trigger every 29 days


### PR DESCRIPTION
Fixed an issue with grafana api rotation and kms keys.
Had to skip CKV2_AWS_57: Secrets need auto rotation as it will flag the grafana workspace id.
Will look at trying to ignore individual resources but will need pr merged to fix current issue.